### PR TITLE
add new management command to automatically sync ldap users

### DIFF
--- a/labshare/management/commands/sync_users.py
+++ b/labshare/management/commands/sync_users.py
@@ -1,0 +1,61 @@
+import ldap
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.management import BaseCommand
+from django_auth_ldap.backend import _LDAPUser
+from django_auth_ldap.config import LDAPSearch
+
+from labshare.backends.authentication.ldap import LDAPBackend
+
+
+class Command(BaseCommand):
+    help = "Syncs current user database with all known users in the LDAP Database"
+
+    def process_user_list(self, ldap_users: list) -> list:
+        # convert list of all ldap uids to a list of usernames if the user has a valid mail address
+        converted_users = []
+        for dn, user_data in ldap_users:
+            if 'mail' in user_data:
+                converted_users.append(user_data['uid'][0])
+
+        return converted_users
+
+    def filter_django_users(self, users: list) -> list:
+        return [user for user in users if len(user.email) > 0 and not hasattr(user, 'device')]
+
+    def handle(self, *args, **options):
+        ldap_backend = LDAPBackend()
+        dummy_user = _LDAPUser(ldap_backend, username="dummy")
+        user_search = LDAPSearch(settings.AUTH_LDAP_USER_DN, ldap.SCOPE_SUBTREE, "(uid=*)")
+
+        user_data = user_search.execute(dummy_user.connection)
+        list_of_current_ldap_users = self.process_user_list(user_data)
+
+        known_users = self.filter_django_users(User.objects.all())
+        num_deleted_users = 0
+        num_imported_users = 0
+
+        for user in known_users:
+            if user.username in list_of_current_ldap_users:
+                index = list_of_current_ldap_users.index(user.username)
+                list_of_current_ldap_users.pop(index)
+            else:
+                if not user.is_superuser:
+                    user.delete()
+                    num_deleted_users += 1
+
+        # if there are any usernames left, we need to add new users to the database
+        for username in list_of_current_ldap_users:
+            django_user = ldap_backend.populate_user(username)
+            if django_user is None:
+                self.stderr.write(self.style.ERROR(f"Could not create user with username {username}"))
+                continue
+
+            ldap_backend.update_mail_addresses(django_user)
+            ldap_backend.set_groups_of_user(django_user)
+
+            num_imported_users += 1
+
+        self.stdout.write(self.style.SUCCESS("Import Complete"))
+        self.stdout.write(self.style.SUCCESS(f"Imported {num_imported_users} users into the database."))
+        self.stdout.write(self.style.SUCCESS(f"Deleted {num_deleted_users} users from the database."))

--- a/labshare/settings.py
+++ b/labshare/settings.py
@@ -23,7 +23,8 @@ AUTH_LDAP_USER_ATTR_MAP = {
     "email": "mail"
 }
 AUTH_LDAP_SERVER_URI = "ldaps://example.com"
-AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=People,dc=example,dc=com", ldap.SCOPE_SUBTREE, "(uid=%(user)s)")
+AUTH_LDAP_USER_DN = "ou=People,dc=example,dc=com"
+AUTH_LDAP_USER_SEARCH = LDAPSearch(AUTH_LDAP_USER_DN, ldap.SCOPE_SUBTREE, "(uid=%(user)s)")
 
 AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
     "ou=Group,dc=example,dc=com", ldap.SCOPE_SUBTREE, "(objectClass=groupOfNames)"

--- a/labshare/test_management_commands.py
+++ b/labshare/test_management_commands.py
@@ -1,0 +1,136 @@
+import random
+import string
+from unittest import mock
+
+from django.contrib.auth.models import User
+from django.core import management
+from django.test import TestCase
+from model_bakery import baker
+
+from labshare.tests import device_recipe
+
+
+def get_ldap_users(num_users: int) -> list:
+    ldap_data = []
+    for user_id in range(num_users):
+        user_name = ''.join([random.choice(string.ascii_letters) for _ in range(random.randint(5, 20))])
+        user_data = (
+            user_name,
+            {
+                "mail": ["random@random.org"],
+                "uid": [user_name],
+                "uidnumber": [f'{random.randint(100, 10000)}'],
+                "gidnumber": [f'{random.randint(100, 10000)}'],
+                "sn": [user_name],
+                "cn": [user_name]
+            }
+        )
+        ldap_data.append(user_data)
+    return ldap_data
+
+
+class LDAPSearchMock:
+
+    def __init__(self, num_users):
+        self.user_data = get_ldap_users(num_users)
+        self.user_dns = [dn for dn, _ in self.user_data]
+
+    def init(self, base_dn, *args, **kwargs):
+        self.base_dn = base_dn
+
+    def execute(self, *args, **kwargs):
+        if self.base_dn in self.user_dns:
+            # we are searching for a specific user
+            for user in self.user_data:
+                    if user[0] == self.base_dn:
+                        return [user]
+
+        if len(args) == 1:
+            # we want to get all available users
+            return self.user_data
+        else:
+            # we are looking for a specific user by username and not dn
+            filter_args = args[1]
+            for user in self.user_data:
+                if user[1]['uid'][0] == filter_args['user']:
+                    return [user]
+
+
+class SyncUsersTests(TestCase):
+
+    def setUp(self):
+        self.user = baker.make(User)
+        self.device = device_recipe.make()
+
+    def check_that_correct_users_are_in_database(self, search_mock):
+        imported_users = User.objects.filter(username__in=search_mock.user_dns)
+        imported_usernames = [user.username for user in imported_users]
+        for user_dn in search_mock.user_dns:
+            self.assertIn(user_dn, imported_usernames)
+
+    def test_sync_users_new_users_in_ldap(self):
+        num_users_before_update = User.objects.count()
+        num_users_to_add = 3
+        search_mock = LDAPSearchMock(num_users_to_add)
+
+        with mock.patch('django_auth_ldap.backend.LDAPSearch.execute') as mocked_execute, \
+             mock.patch('django_auth_ldap.backend.LDAPSearch.__init__') as mocked_init, \
+             mock.patch('django_auth_ldap.backend._LDAPUser._bind_as') as mocked_bind:
+            mocked_init.side_effect = search_mock.init
+            mocked_execute.side_effect = search_mock.execute
+            mocked_bind.return_value = None
+
+            management.call_command('sync_users')
+
+        self.assertEqual(User.objects.count(), num_users_before_update + num_users_to_add)
+        self.check_that_correct_users_are_in_database(search_mock)
+
+    def test_sync_users_remove_users_from_ldap(self):
+        num_users_before_update = User.objects.count()
+        num_users_to_add = 3
+        search_mock = LDAPSearchMock(num_users_to_add)
+
+        with mock.patch('django_auth_ldap.backend.LDAPSearch.execute') as mocked_execute, \
+             mock.patch('django_auth_ldap.backend.LDAPSearch.__init__') as mocked_init, \
+             mock.patch('django_auth_ldap.backend._LDAPUser._bind_as') as mocked_bind:
+            mocked_init.side_effect = search_mock.init
+            mocked_execute.side_effect = search_mock.execute
+            mocked_bind.return_value = None
+
+            management.call_command('sync_users')
+
+            search_mock.user_data.pop()
+            search_mock.user_dns.pop()
+
+            management.call_command('sync_users')
+
+        self.assertEqual(User.objects.count(), num_users_before_update + num_users_to_add - 1)
+        self.check_that_correct_users_are_in_database(search_mock)
+
+    def test_sync_users_add_and_remove_user_from_ldap(self):
+        num_users_before_update = User.objects.count()
+        num_users_to_add = 3
+        search_mock = LDAPSearchMock(num_users_to_add)
+
+        with mock.patch('django_auth_ldap.backend.LDAPSearch.execute') as mocked_execute, \
+             mock.patch('django_auth_ldap.backend.LDAPSearch.__init__') as mocked_init, \
+             mock.patch('django_auth_ldap.backend._LDAPUser._bind_as') as mocked_bind:
+            mocked_init.side_effect = search_mock.init
+            mocked_execute.side_effect = search_mock.execute
+            mocked_bind.return_value = None
+
+            management.call_command('sync_users')
+
+            search_mock.user_data.pop()
+            search_mock.user_dns.pop()
+
+            new_user = get_ldap_users(1)
+            search_mock.user_data.extend(new_user)
+            search_mock.user_dns.append(new_user[0][0])
+
+            management.call_command('sync_users')
+
+        self.assertEqual(User.objects.count(), num_users_before_update + num_users_to_add)
+        self.check_that_correct_users_are_in_database(search_mock)
+
+


### PR DESCRIPTION
allows us to build a reoccuring job that keeps the labshare databse in sync with our LDAP. Should be useful if we want to send messages to all users but not everybody logged into labshare before...